### PR TITLE
build(flags): add -trimpath to binary builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
 
     - name: Build main CLI
       run: |
-        go build -v -ldflags="-s -w" -o dist/dtvem${{ matrix.goos == 'windows' && '.exe' || '' }} ./src
+        go build -v -ldflags="-s -w" -trimpath -o dist/dtvem${{ matrix.goos == 'windows' && '.exe' || '' }} ./src
       shell: bash
       env:
         GOOS: ${{ matrix.goos }}
@@ -182,7 +182,7 @@ jobs:
 
     - name: Build shim executable
       run: |
-        go build -v -ldflags="-s -w" -o dist/dtvem-shim${{ matrix.goos == 'windows' && '.exe' || '' }} ./src/cmd/shim
+        go build -v -ldflags="-s -w" -trimpath -o dist/dtvem-shim${{ matrix.goos == 'windows' && '.exe' || '' }} ./src/cmd/shim
       shell: bash
       env:
         GOOS: ${{ matrix.goos }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
 
     - name: Build main CLI
       run: |
-        go build -v -ldflags="-s -w" -o dist/dtvem${{ matrix.goos == 'windows' && '.exe' || '' }} ./src
+        go build -v -ldflags="-s -w" -trimpath -o dist/dtvem${{ matrix.goos == 'windows' && '.exe' || '' }} ./src
       shell: bash
       env:
         GOOS: ${{ matrix.goos }}
@@ -187,7 +187,7 @@ jobs:
 
     - name: Build shim executable
       run: |
-        go build -v -ldflags="-s -w" -o dist/dtvem-shim${{ matrix.goos == 'windows' && '.exe' || '' }} ./src/cmd/shim
+        go build -v -ldflags="-s -w" -trimpath -o dist/dtvem-shim${{ matrix.goos == 'windows' && '.exe' || '' }} ./src/cmd/shim
       shell: bash
       env:
         GOOS: ${{ matrix.goos }}

--- a/rnr.yaml
+++ b/rnr.yaml
@@ -24,11 +24,11 @@ build:
 
 build-cli:
   description: Build the main CLI executable
-  cmd: go build -v -ldflags="-s -w" -o dist/dtvem.exe ./src
+  cmd: go build -v -ldflags="-s -w" -trimpath -o dist/dtvem.exe ./src
 
 build-shim:
   description: Build the shim executable
-  cmd: go build -v -ldflags="-s -w" -o dist/dtvem-shim.exe ./src/cmd/shim
+  cmd: go build -v -ldflags="-s -w" -trimpath -o dist/dtvem-shim.exe ./src/cmd/shim
 
 # Deployment (Windows)
 deploy-local:


### PR DESCRIPTION
## Summary

- Add `-trimpath` to `go build` in `rnr.yaml` (local builds) and both `.github/workflows/build.yml` and `.github/workflows/release.yml` (CI / release).
- Drops the shim from 8.20 MB → 5.70 MB (**-30%**) and the main CLI by a similar proportion, with zero runtime behavior change.
- First step in a broader effort to slim the shim; structural follow-up (provider import split) will be a separate PR.

## Measured impact (local, Windows amd64, `-s -w` already in place)

| Binary | Before | After | Δ |
|---|---|---|---|
| `dtvem-shim.exe` | 8.20 MB | 5.70 MB | **-2.50 MB (-30%)** |
| `dtvem.exe` | 14.83 MB | 10.94 MB | **-3.88 MB (-26%)** |

Savings compound across the five release platforms (`windows-amd64/arm64`, `darwin-amd64/arm64`, `linux-amd64`).

## What `-trimpath` does

Replaces absolute filesystem paths in the compiled binary with the module path. Runtime behavior is unchanged. The only user-visible difference is in panic stack traces, which show module-relative paths instead of build-machine paths — a positive for reproducibility/debuggability of shipped binaries.

## Test plan

- [x] `./rnr.cmd check` passes (format, lint, full test suite — all packages OK)
- [x] Direct `go build` with new flags produces working binaries at the expected sizes
- [ ] CI build workflow succeeds on this PR for all five matrix platforms
- [ ] Smoke test: install the shim from a built artifact and run `python --version` / `node --version` to verify the runtime hot path is unaffected

## Notes

- The local `./rnr build` task has a pre-existing YAML-quoting bug that affects any task using `-ldflags="-s -w"`. This PR does not fix it; tracked separately in #263 (with upstream report CodingWithCalvin/rnr.cli#55). CI is unaffected because `.github/workflows/{build,release}.yml` run under `shell: bash`, which tokenizes the quoted flag correctly.

Resolves [#262](https://github.com/CodingWithCalvin/dtvem.cli/issues/262)